### PR TITLE
support ruby 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.8.4"
+gem "jekyll", "3.9.3"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
@@ -20,3 +20,6 @@ group :jekyll_plugins do
     gem "jekyll-paginate", "~> 1.1.0"
     # gem 'wdm', '>= 0.1.0'
 end
+
+gem "webrick", "~> 1.8"
+gem "kramdown-parser-gfm", "~> 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.0.5)
-    em-websocket (0.5.1)
+    concurrent-ruby (1.2.2)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
-    ffi (1.9.25)
-    ffi (1.9.25-x64-mingw32)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
-    http_parser.rb (0.6.0)
-    i18n (0.9.5)
+    http_parser.rb (0.8.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (3.9.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (>= 1.17, < 3)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
@@ -32,40 +31,45 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-watch (2.1.2)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (1.17.0)
-    liquid (4.0.1)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.8.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.3)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    rouge (3.3.0)
-    ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.6.0)
+    public_suffix (5.0.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.5)
+    rouge (3.30.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    webrick (1.8.1)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
   x64-mingw32
 
 DEPENDENCIES
-  jekyll (= 3.8.4)
+  jekyll (= 3.9.3)
   jekyll-paginate (~> 1.1.0)
+  kramdown-parser-gfm (~> 1.1.0)
+  webrick (~> 1.8)
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 3.2.2p53
 
 BUNDLED WITH
-   1.14.6
+   2.4.14

--- a/_plugins/generate_categories.rb
+++ b/_plugins/generate_categories.rb
@@ -47,7 +47,7 @@ module Jekyll
 
     # make sure this is the same as baseurl in _config.yaml
     BASEURL =  Jekyll.configuration({})['baseurl']
-    BASEURL = "" if (BASEURL == nil) else BASEURL
+    BASEURL = "" if (BASEURL == nil)
 
   # The CategoryIndex class creates a single category page for the specified category.
   class CategoryIndex < Page


### PR DESCRIPTION
Support Ruby 3.x (Ruby 2.7 is EOL since March 31, 2023).

* add Webrick to Gemfile
* upgrade Jekyll to 3.9.3 (the version also officially supported by GitHub Pages)
* fix categories code that raises a runtime error