### PR TITLE
increase feed.posts_imit to 50

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -54,7 +54,7 @@ layout: null
     {% assign posts = site.posts | where_exp: "post", "post.draft != true" %}
   {% endunless %}
   {% assign posts = site.posts | sort: "date" | reverse %}
-  {% assign posts_limit = site.feed.posts_limit | default: 25 %}
+  {% assign posts_limit = site.feed.posts_limit | default: 50 %}
   {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       {% assign post_title = post.title | smartify | strip_html | normalize_whitespace | xml_escape %}


### PR DESCRIPTION
This will include all posts (currently 30) in the RSS feed, including some important early ones. Current value is 25. I don't see any disadvantages as 50 is still relatively low.